### PR TITLE
Posts on profile

### DIFF
--- a/client/src/components/FeedCard/index.js
+++ b/client/src/components/FeedCard/index.js
@@ -10,6 +10,9 @@ class FeedCard extends Component {
   }
 
   render() {
+    const startDate = new Date(this.props.startDate);
+    const endDate = new Date(this.props.endDate);
+
     return (
       <Jumbotron>
         <Card style={{ width: "auto" }}>
@@ -41,9 +44,14 @@ class FeedCard extends Component {
             ) : null}
             <p>Location: {this.props.location}.</p>
             <p>
-              When: {new Date(this.props.startDate).toString()}
+              When:{" "}
+              {`${
+                startDate.getMonth() + 1
+              }/${startDate.getDate()}/${startDate.getFullYear()}`}
               {this.props.endDate !== ``
-                ? ` until ${new Date(this.props.endDate).toString()}`
+                ? ` until ${`${
+                    endDate.getMonth() + 1
+                  }/${endDate.getDate()}/${endDate.getFullYear()}`}`
                 : null}
               .
             </p>

--- a/client/src/components/FeedCard/index.js
+++ b/client/src/components/FeedCard/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Card from "react-bootstrap/Card";
 import Jumbotron from "react-bootstrap/Jumbotron";
+import API from "../../utils/API";
 
 class FeedCard extends Component {
   constructor(props) {
@@ -14,7 +15,21 @@ class FeedCard extends Component {
         <Card style={{ width: "auto" }}>
           <Card.Body>
             <h1>{this.props.title}</h1>
-            {this.props.delete ? <button>DELETE</button> : null}
+            {this.props.delete ? (
+              <button
+                onClick={() =>
+                  this.props.deletePost(this.props.id, this.props.author)
+                }
+              >
+                DELETE
+              </button>
+            ) : null}
+            {this.props.complete !== `negative` ? (
+              <div>
+                <button>TOGGLE STATUS</button>
+                <p>Status: {this.props.complete}</p>
+              </div>
+            ) : null}
             <p>Location: {this.props.location}.</p>
             <p>
               When: {new Date(this.props.startDate).toString()}

--- a/client/src/components/FeedCard/index.js
+++ b/client/src/components/FeedCard/index.js
@@ -24,9 +24,18 @@ class FeedCard extends Component {
                 DELETE
               </button>
             ) : null}
-            {this.props.complete !== `negative` ? (
+            {this.props.delete && this.props.complete !== `negative` ? (
               <div>
-                <button>TOGGLE STATUS</button>
+                <button
+                  onClick={() =>
+                    this.props.togglePostStatus(
+                      this.props.id,
+                      this.props.complete
+                    )
+                  }
+                >
+                  TOGGLE STATUS
+                </button>
                 <p>Status: {this.props.complete}</p>
               </div>
             ) : null}

--- a/client/src/components/FeedCard/index.js
+++ b/client/src/components/FeedCard/index.js
@@ -1,35 +1,34 @@
-import React from "react";
+import React, { Component } from "react";
 import Card from "react-bootstrap/Card";
 import Jumbotron from "react-bootstrap/Jumbotron";
 
-function FeedCard(props) {
-  return (
-    <Jumbotron>
-      <Card style={{ width: "auto" }}>
-        <Card.Body>
-          <h1>{props.title}</h1>
-          <p>Location: {props.location}.</p>
-          <p>
-            When: {new Date(props.startDate).toString()}
-            {props.endDate !== ``
-              ? ` until ${new Date(props.endDate).toString()}`
-              : null}
-            .
-          </p>
-          <p>Description: {props.description}</p>
+class FeedCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
 
-          {/* <Row>
-            <Col md={"2"}>
-              <Image src={UserTest} style={{ maxWidth: 80 }} roundedCircle />
-            </Col>
-            <Col>
-              <h3>{props.username}</h3>
-            </Col>
-          </Row> */}
-        </Card.Body>
-      </Card>
-    </Jumbotron>
-  );
+  render() {
+    return (
+      <Jumbotron>
+        <Card style={{ width: "auto" }}>
+          <Card.Body>
+            <h1>{this.props.title}</h1>
+            {this.props.delete ? <button>DELETE</button> : null}
+            <p>Location: {this.props.location}.</p>
+            <p>
+              When: {new Date(this.props.startDate).toString()}
+              {this.props.endDate !== ``
+                ? ` until ${new Date(this.props.endDate).toString()}`
+                : null}
+              .
+            </p>
+            <p>Description: {this.props.description}</p>
+          </Card.Body>
+        </Card>
+      </Jumbotron>
+    );
+  }
 }
 
 export default FeedCard;

--- a/client/src/components/FeedCard/index.js
+++ b/client/src/components/FeedCard/index.js
@@ -2,14 +2,33 @@ import React, { Component } from "react";
 import Card from "react-bootstrap/Card";
 import Jumbotron from "react-bootstrap/Jumbotron";
 import API from "../../utils/API";
+import { Redirect } from "react-router-dom";
 
 class FeedCard extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      redirect: null,
+      id: ``,
+    };
   }
 
   render() {
+    if (this.state.redirect) {
+      const redir = this.state.redirect;
+      this.setState({ redirect: null });
+      return (
+        <Redirect
+          to={{
+            pathname: redir,
+            state: {
+              userID: this.state.id,
+            },
+          }}
+        />
+      );
+    }
+
     const startDate = new Date(this.props.startDate);
     const endDate = new Date(this.props.endDate);
 
@@ -18,6 +37,16 @@ class FeedCard extends Component {
         <Card style={{ width: "auto" }}>
           <Card.Body>
             <h1>{this.props.title}</h1>
+            <button
+              onClick={() => {
+                this.setState({
+                  redirect: `/userdetails`,
+                  id: this.props.author,
+                });
+              }}
+            >
+              CONTACT POSTER
+            </button>
             {this.props.delete ? (
               <button
                 onClick={() =>

--- a/client/src/components/FeedComponent/index.js
+++ b/client/src/components/FeedComponent/index.js
@@ -161,6 +161,7 @@ class FeedComponent extends Component {
                   ? this.state.filteredPosts.map((post, index) => {
                       return (
                         <FeedCard
+                          author={post.author}
                           key={index}
                           title={post.title}
                           location={post.location}

--- a/client/src/components/FeedComponent/index.js
+++ b/client/src/components/FeedComponent/index.js
@@ -60,9 +60,13 @@ class FeedComponent extends Component {
     API.getPosts()
       .then(response => {
         console.log(response.data);
-        const sortedPosts = response.data.sort((a, b) =>
-          b.startDate > a.startDate ? 1 : -1
-        );
+        const sortedPosts = response.data
+          .filter(
+            post =>
+              post.complete === false && new Date(post.endDate) > new Date()
+          )
+          .sort((a, b) => (b.startDate > a.startDate ? 1 : -1));
+
         this.setState({ posts: sortedPosts, filteredPosts: sortedPosts });
       })
       .catch(err => console.error(err));

--- a/client/src/components/FeedComponent/index.js
+++ b/client/src/components/FeedComponent/index.js
@@ -45,17 +45,6 @@ class FeedComponent extends Component {
     this.setState({ filteredPosts: this.state.posts });
   };
 
-  //   author: "5ea863ce84d81942203caba9"
-  // complete: false
-  // description: "Looking for a show, any ideas please get in touch!"
-  // endDate: "2020-01-01T00:00:00.000Z"
-  // location: "Seattle"
-  // postedDate: "2020-05-06T20:21:49.558Z"
-  // startDate: "2019-01-01T00:00:00.000Z"
-  // title: "Looking for a show"
-  // type: "artistNeeded"
-  // _id: "5ea866f6298ddd2a5c1de8fc"
-
   getPosts = () => {
     API.getPosts()
       .then(response => {

--- a/client/src/components/ProfileComponent/index.js
+++ b/client/src/components/ProfileComponent/index.js
@@ -4,6 +4,7 @@ import "./style.css";
 import image from "../../assets/images/userTest.png";
 import { Link, Redirect } from "react-router-dom";
 import FeedCard from "../FeedCard";
+import API from "../../utils/API";
 
 class ProfileComponent extends Component {
   constructor(props) {
@@ -12,6 +13,19 @@ class ProfileComponent extends Component {
       redirect: null,
     };
   }
+
+  // deletePost = (id, author) => {
+  //   API.deletePost(id)
+  //     .then(data => {
+  //       API.updateRemoveUserPost(author, {
+  //         id: data.data._id,
+  //       })
+  //         .then(data => console.log(data))
+  //         .catch(err => console.error(err));
+  //     })
+  //     .catch(err => console.error(err));
+  // };
+
   render() {
     if (this.state.redirect) {
       const redir = this.state.redirect;
@@ -78,7 +92,11 @@ class ProfileComponent extends Component {
               return (
                 <FeedCard
                   key={index}
+                  id={post._id}
+                  author={post.author}
+                  deletePost={this.props.deletePost}
                   delete={true}
+                  complete={post.complete ? `closed` : `open`}
                   title={post.title}
                   location={post.location}
                   startDate={post.startDate}
@@ -97,6 +115,7 @@ class ProfileComponent extends Component {
                   <FeedCard
                     key={index}
                     delete={false}
+                    complete={`negative`}
                     title={post.title}
                     location={post.location}
                     startDate={post.startDate}

--- a/client/src/components/ProfileComponent/index.js
+++ b/client/src/components/ProfileComponent/index.js
@@ -95,6 +95,7 @@ class ProfileComponent extends Component {
                   id={post._id}
                   author={post.author}
                   deletePost={this.props.deletePost}
+                  togglePostStatus={this.props.togglePostStatus}
                   delete={true}
                   complete={post.complete ? `closed` : `open`}
                   title={post.title}

--- a/client/src/components/ProfileComponent/index.js
+++ b/client/src/components/ProfileComponent/index.js
@@ -14,18 +14,6 @@ class ProfileComponent extends Component {
     };
   }
 
-  // deletePost = (id, author) => {
-  //   API.deletePost(id)
-  //     .then(data => {
-  //       API.updateRemoveUserPost(author, {
-  //         id: data.data._id,
-  //       })
-  //         .then(data => console.log(data))
-  //         .catch(err => console.error(err));
-  //     })
-  //     .catch(err => console.error(err));
-  // };
-
   render() {
     if (this.state.redirect) {
       const redir = this.state.redirect;
@@ -89,6 +77,7 @@ class ProfileComponent extends Component {
           this.props.posts.length > 0 &&
           this.props.userId ? (
             this.props.posts.map((post, index) => {
+              // props if user in session profile
               return (
                 <FeedCard
                   key={index}
@@ -112,6 +101,7 @@ class ProfileComponent extends Component {
             this.props.posts
               .sort((a, b) => (b.startDate > a.startDate ? 1 : -1))
               .map((post, index) => {
+                // props for generic profile
                 return (
                   <FeedCard
                     key={index}

--- a/client/src/components/ProfileComponent/index.js
+++ b/client/src/components/ProfileComponent/index.js
@@ -28,7 +28,10 @@ class ProfileComponent extends Component {
         <hr></hr>
         <Image className="pic" src={image} alt="profile pic" />
         <br></br>
-        <p className="username">Welcome, {this.props.username}</p>
+        <p className="username">
+          {this.props.userId ? `Welcome, ` : null}
+          {this.props.username}
+        </p>
 
         <div className="shade w-75">
           <div className="info">

--- a/client/src/components/ProfileComponent/index.js
+++ b/client/src/components/ProfileComponent/index.js
@@ -11,6 +11,8 @@ class ProfileComponent extends Component {
     super(props);
     this.state = {
       redirect: null,
+      editMode: false,
+      status: ``,
     };
   }
 
@@ -43,11 +45,45 @@ class ProfileComponent extends Component {
             <span>Phone:</span>
             <p>{this.props.telephone}</p>
           </div>
-
-          <div className="info">
-            <span>Status:</span>
-            <p>{this.props.status}</p>
-          </div>
+          {this.props.userId ? (
+            <div
+              className="info"
+              onClick={() => {
+                this.setState({ editMode: true });
+              }}
+            >
+              <span>Status (click to edit):</span>
+              {this.state.editMode ? (
+                <input
+                  id="status-field"
+                  placeholder="Hit Esc key to cancel"
+                  onChange={event =>
+                    this.setState({ status: event.target.value })
+                  }
+                  // onBlur={() => this.setState({ editMode: false, status: `` })}
+                  onKeyUp={event => {
+                    if (event.keyCode === 27) {
+                      this.setState({ editMode: false, status: `` });
+                    }
+                    if (event.keyCode === 13) {
+                      this.props.editStatus(
+                        this.props.userId,
+                        this.state.status
+                      );
+                      this.setState({ editMode: false, status: `` });
+                    }
+                  }}
+                />
+              ) : (
+                <p>{this.props.status}</p>
+              )}
+            </div>
+          ) : (
+            <div className="info">
+              <span>Status:</span>
+              <p>{this.props.status}</p>
+            </div>
+          )}
 
           <div className="info">
             <span>Role:</span>

--- a/client/src/components/ProfileComponent/index.js
+++ b/client/src/components/ProfileComponent/index.js
@@ -3,6 +3,7 @@ import { Image } from "react-bootstrap";
 import "./style.css";
 import image from "../../assets/images/userTest.png";
 import { Link, Redirect } from "react-router-dom";
+import FeedCard from "../FeedCard";
 
 class ProfileComponent extends Component {
   constructor(props) {
@@ -70,14 +71,43 @@ class ProfileComponent extends Component {
           </Link>
         ) : null}
         <div className="shade w-75">
-          <p>This is a sample post</p>
-          {/* {props.posts !== undefined ? (
-        <ul>
-          {props.posts.map(post => (
-            <li>{post.description}</li>
-          ))}
-        </ul>
-      ) : null} */}
+          {this.props.posts !== undefined &&
+          this.props.posts.length > 0 &&
+          this.props.userId ? (
+            this.props.posts.map((post, index) => {
+              return (
+                <FeedCard
+                  key={index}
+                  delete={true}
+                  title={post.title}
+                  location={post.location}
+                  startDate={post.startDate}
+                  endDate={post.endDate}
+                  description={post.description}
+                />
+              );
+            })
+          ) : this.props.posts !== undefined &&
+            this.props.posts.length > 0 &&
+            !this.props.userId ? (
+            this.props.posts
+              .sort((a, b) => (b.startDate > a.startDate ? 1 : -1))
+              .map((post, index) => {
+                return (
+                  <FeedCard
+                    key={index}
+                    delete={false}
+                    title={post.title}
+                    location={post.location}
+                    startDate={post.startDate}
+                    endDate={post.endDate}
+                    description={post.description}
+                  />
+                );
+              })
+          ) : (
+            <p>No posts yet!</p>
+          )}
         </div>
       </div>
     );

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -55,6 +55,15 @@ class Profile extends Component {
     this.setState(userObject);
   };
 
+  editStatus = (id, status) => {
+    API.updateUser(id, { status: status })
+      .then(data => {
+        console.log(data);
+        this.getUser();
+      })
+      .catch(err => console.error(err));
+  };
+
   getUser = () => {
     axios.get("/api/user/").then(response => {
       console.log("Get user response: ");
@@ -111,6 +120,7 @@ class Profile extends Component {
                   <ProfileComponent
                     deletePost={this.deletePost}
                     togglePostStatus={this.togglePostStatus}
+                    editStatus={this.editStatus}
                     userId={this.state.user.id}
                     username={this.state.user.username}
                     location={this.state.user.location}

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -21,6 +21,21 @@ class Profile extends Component {
     this.getUser();
   };
 
+  deletePost = (id, author) => {
+    API.deletePost(id)
+      .then(data => {
+        API.updateRemoveUserPost(author, {
+          id: data.data._id,
+        })
+          .then(data => {
+            console.log(data);
+            this.getUser();
+          })
+          .catch(err => console.error(err));
+      })
+      .catch(err => console.error(err));
+  };
+
   updateUser = userObject => {
     this.setState(userObject);
   };
@@ -79,6 +94,7 @@ class Profile extends Component {
               <Container>
                 <div>
                   <ProfileComponent
+                    deletePost={this.deletePost}
                     userId={this.state.user.id}
                     username={this.state.user.username}
                     location={this.state.user.location}

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -36,6 +36,21 @@ class Profile extends Component {
       .catch(err => console.error(err));
   };
 
+  togglePostStatus = (id, status) => {
+    let newStatus;
+    if (status === `open`) {
+      newStatus = true;
+    } else if (status === `closed`) {
+      newStatus = false;
+    }
+    API.updatePost(id, { complete: newStatus })
+      .then(data => {
+        console.log(data);
+        this.getUser();
+      })
+      .catch(err => console.error(err));
+  };
+
   updateUser = userObject => {
     this.setState(userObject);
   };
@@ -95,6 +110,7 @@ class Profile extends Component {
                 <div>
                   <ProfileComponent
                     deletePost={this.deletePost}
+                    togglePostStatus={this.togglePostStatus}
                     userId={this.state.user.id}
                     username={this.state.user.username}
                     location={this.state.user.location}

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -34,4 +34,7 @@ export default {
   deletePost(id) {
     return axios.delete(`/api/classifieds/${id}`);
   },
+  updatePost(id, postData) {
+    return axios.put(`/api/classifieds/${id}`, postData);
+  },
 };

--- a/scripts/ClassifiedSeedDB.js
+++ b/scripts/ClassifiedSeedDB.js
@@ -23,7 +23,7 @@ const postsSeed = [
     description: `Looking for a show, any ideas please get in touch!`,
     location: `Seattle`,
     startDate: `2019-01-01T00:00:00.000Z`,
-    endDate: `2020-01-01T00:00:00.000Z`,
+    endDate: `2021-01-01T00:00:00.000Z`,
   },
   {
     _id: mongoose.Types.ObjectId(`5ea866f6298ddd2a5c1de8fd`),
@@ -33,7 +33,7 @@ const postsSeed = [
     description: `Looking for a band, any ideas please get in touch!`,
     location: `New York`,
     startDate: `2019-01-01T00:00:00.000Z`,
-    endDate: `2020-01-01T00:00:00.000Z`,
+    endDate: `2021-01-01T00:00:00.000Z`,
   },
   {
     _id: mongoose.Types.ObjectId(`5ea866f6298ddd2a5c1de8fe`),
@@ -43,7 +43,7 @@ const postsSeed = [
     description: `Looking for a DJ, any ideas please get in touch!`,
     location: `Portland`,
     startDate: `2019-01-01T00:00:00.000Z`,
-    endDate: `2020-01-01T00:00:00.000Z`,
+    endDate: `2021-01-01T00:00:00.000Z`,
   },
   {
     _id: mongoose.Types.ObjectId(`5ea866f6298ddd2a5c1de8ff`),
@@ -53,7 +53,7 @@ const postsSeed = [
     description: `Looking for a guitar, any ideas please get in touch!`,
     location: `Vancouver`,
     startDate: `2019-01-01T00:00:00.000Z`,
-    endDate: `2020-01-01T00:00:00.000Z`,
+    endDate: `2021-01-01T00:00:00.000Z`,
   },
   {
     _id: mongoose.Types.ObjectId(`5ea866f6298ddd2a5c1de900`),
@@ -63,7 +63,7 @@ const postsSeed = [
     description: `Looking for a place to crash, any ideas please get in touch!`,
     location: `L.A.`,
     startDate: `2019-01-01T00:00:00.000Z`,
-    endDate: `2020-01-01T00:00:00.000Z`,
+    endDate: `2021-01-01T00:00:00.000Z`,
   },
 ];
 


### PR DESCRIPTION
1. Posts display on user profiles, in session user has the ability to delete, which refreshes the posts being displayed

2. User can toggle the status of the post - if it is completed, maybe the user doesn't want to delete the post altogether because the situation may change (another band may pull out)

3. The news feed only shows posts that a) haven't expired in time and b) are set to uncomplete still. (in profile view, all posts are showed)

4. (minor) dates have been formatted to look better (mm/dd/yyyy)

5. User can update their status - the procedure is not as clean as I'd like, I'd like to `.focus()` on the status update field when it appears but I couldn't get that going - play with it and you'll see

6. Added a way for users to contact the poster of a post, just by adding a button that takes them to their profile where the contact details are. MVP+ would be able to leave comments or use an in-house message system, MVP++ would email as well

7. (minor) when you view a profile, if it's your profile it says welcome, if someone else's it doesn't

