### PR TITLE
moved logic for reconnection logic to app.js

### DIFF
--- a/client/src/components/FeedComponent/index.js
+++ b/client/src/components/FeedComponent/index.js
@@ -18,6 +18,7 @@ class FeedComponent extends Component {
       postTypes: [
         { filterTerm: `artistNeeded`, displayTerm: `Artist Needed` },
         { filterTerm: `showNeeded`, displayTerm: `Show Needed` },
+        { filterTerm: `promoterNeeded`, displayTerm: `Promoter Needed` },
       ],
       locationSearch: ``,
       redirect: null,


### PR DESCRIPTION
The main thing I did here is to move the re-connection logic to app.js. This is because if you go offline, the post will be successful, but once you get back online it won't attempt to post until you navigate back to the make-a-post page, which you may not do. Now, since this reconnection logic is in app, App checks to see if there is anything in indexedDB storage on load (if there is a connection), if there is, it will post however many in the array to the DB.

One thing I tried to do was to pass around a user object in offline mode, but was unsuccessful. This means that the practical use of this offline feature is that the user has to be on the make-a-post page already, so picture a situation where the user is already writing a post and the connection drops, or they go through a tunnel or something. What can't happen presently is that the user can't be offline and then navigate to the make-a-post page, because this will not be able to getUser(), and I was unsuccessful in cleanly providing that information.